### PR TITLE
Get rid of Latin1 "smart quotes" in a file

### DIFF
--- a/boost/container/detail/advanced_insert_int.hpp
+++ b/boost/container/detail/advanced_insert_int.hpp
@@ -288,7 +288,7 @@ struct insert_emplace_proxy<A, Iterator, typename boost::container::allocator_tr
 };
 
 //We use "add_const" here as adding "const" only confuses MSVC12(and maybe later) provoking
-//compiler error C2752 (“more than one partial specialization matches”).
+//compiler error C2752 ("more than one partial specialization matches").
 //Any problem is solvable with an extra layer of indirection? ;-)
 template<class A, class Iterator>
 struct insert_emplace_proxy<A, Iterator
@@ -433,7 +433,7 @@ struct insert_emplace_proxy_arg1<A, Iterator, typename boost::container::allocat
 };
 
 //We use "add_const" here as adding "const" only confuses MSVC10&11 provoking
-//compiler error C2752 (“more than one partial specialization matches”).
+//compiler error C2752 ("more than one partial specialization matches").
 //Any problem is solvable with an extra layer of indirection? ;-)
 template<class A, class Iterator>
 struct insert_emplace_proxy_arg1<A, Iterator


### PR DESCRIPTION
They keep making my compiler print warnings.